### PR TITLE
Tweak markdown node id generation

### DIFF
--- a/Sources/ChatToys/Utils/WebContext.swift
+++ b/Sources/ChatToys/Utils/WebContext.swift
@@ -308,11 +308,7 @@ public actor MarkdownProcessor {
             result.append("[↗](\(key)) \(line)")
             lastUsedKey = key
         }
-        
-        print("✨")
-        print(result.joined(separator: "\n"))
-        print("✨")
-        
+
         return result.joined(separator: "\n")
     }
 }


### PR DESCRIPTION
- Maps from id to webpage text to avoid using identical ids across multiple domains
- Doesn't give ids to certain types of text
- Fixes processWords logic, not sure why I had that flipped

Can abstract or approach differently if you think worthwhile 